### PR TITLE
refactoring test code and making enum equality comparison stable

### DIFF
--- a/src/joinboost/aggregator.py
+++ b/src/joinboost/aggregator.py
@@ -7,39 +7,39 @@ Message = Enum('Message', 'IDENTITY SELECTION FULL UNDECIDED')
 
 
 def parse_agg(agg, para):
-    if agg == Aggregator.SUM:
+    if agg.value == Aggregator.SUM.value:
         assert isinstance(para, str)
         return 'SUM(' + para + ')'
-    elif agg == Aggregator.DISTRIBUTED_SUM_PROD:
+    elif agg.value == Aggregator.DISTRIBUTED_SUM_PROD.value:
         assert isinstance(para, list)
         # para structure: [[sum_column and list of annotated columns in other relations],[...]]
         # example para: [[R1.s, R2.c, R3.c], [R2.s, R1.c, R3.c], [R3.s, R1.c, R2.c]]
         _tmp = ['*'.join(elem) for elem in para]
         # expected: SUM(R1.s*R2.c*R3.c + R2.s*R1.c*R3.c + R3.s*R1.c*R2.c)
         return 'SUM(' + '+'.join(_tmp) + ')'
-    elif agg == Aggregator.SUM_PROD:
+    elif agg.value == Aggregator.SUM_PROD.value:
         assert isinstance(para, dict)
         _tmp = [key + '.' + value for key, value in para.items()]
         return 'SUM(' + '*'.join(_tmp) + ')'
-    elif agg == Aggregator.DISTINCT_COUNT:
+    elif agg.value == Aggregator.DISTINCT_COUNT.value:
         assert isinstance(para, str)
         return 'COUNT(DISTINCT(' + para + '))'
-    elif agg == Aggregator.COUNT:
+    elif agg.value == Aggregator.COUNT.value:
         assert isinstance(para, str)
         return 'COUNT(' + para + ')'
-    elif agg == Aggregator.IDENTITY:
+    elif agg.value == Aggregator.IDENTITY.value:
         return str(para)
-    elif agg == Aggregator.PROD:
+    elif agg.value == Aggregator.PROD.value:
         assert isinstance(para, list)
         _tmp = ['CAST(' + val + ' AS DOUBLE)' for val in para]
         return '*'.join(_tmp) 
-    elif agg == Aggregator.SUB:
+    elif agg.value == Aggregator.SUB.value:
         assert isinstance(para, tuple)
         return str(para[0]) + ' - ' + str(para[1])
-    elif agg == Aggregator.DIV:
+    elif agg.value == Aggregator.DIV.value:
         assert isinstance(para, tuple)
         return str(para[0]) + ' / ' + str(para[1])
-    elif agg == Aggregator.MAX:
+    elif agg.value == Aggregator.MAX.value:
         assert isinstance(para, str)
         return 'MAX(' + para + ')'
     else:

--- a/src/test_joingraph.py
+++ b/src/test_joingraph.py
@@ -1,15 +1,16 @@
 import unittest
 import pandas as pd
+import test_utils
 from joinboost.joingraph import JoinGraph, JoinGraphException
 
 
 class TestJoingraph(unittest.TestCase):
-        
+
     def test_cycle(self):
         R = pd.DataFrame(columns=['A', 'B'])
         S = pd.DataFrame(columns=['B', 'C'])
         T = pd.DataFrame(columns=['A', 'C'])
-    
+
         dataset = JoinGraph()
         try:
             dataset.add_relation('R', ['B', 'E'], relation_address=R)
@@ -19,26 +20,53 @@ class TestJoingraph(unittest.TestCase):
         dataset.add_relation('R', ['B', 'A'], relation_address=R)
         dataset.add_relation('S', ['B', 'C'], relation_address=S)
         dataset.add_relation('T', ['A', 'C'], relation_address=T)
-        
+
         try:
             dataset._preprocess()
             raise Exception('Disjoint join graph is allowed!')
         except JoinGraphException:
             pass
-        
+
         dataset.add_join("R", "S", ["B"], ["B"])
         dataset.add_join("S", "T", ["C"], ["C"])
         dataset._preprocess()
-        
+
         # TODO: check join keys available
         # dataset.add_join("R", "S", ["A"], ["A"])
-        
+
         dataset.add_join("R", "T", ["A"], ["A"])
         try:
             dataset._preprocess()
             raise Exception('Cyclic join graph is allowed!')
         except JoinGraphException:
             pass
-    
+
+    def test_multiplicity_for_many_to_many(self):
+        cjt = test_utils.initialize_synthetic_many_to_many()
+
+        self.assertGreater(cjt.multiplicity['R']['S'], 1)
+        self.assertGreater(cjt.multiplicity['S']['R'], 1)
+        self.assertGreater(cjt.multiplicity['S']['T'], 1)
+        self.assertGreater(cjt.multiplicity['T']['S'], 1)
+
+        self.assertEqual(cjt.missing_keys['S']['R'], 1)
+        self.assertNotIn('S', cjt.missing_keys['R'])
+        self.assertNotIn('R', cjt.missing_keys['T'])
+        self.assertNotIn('T', cjt.missing_keys['R'])
+
+    def test_multiplicity_for_one_to_many(self):
+        cjt = test_utils.initialize_synthetic_one_to_many()
+
+        self.assertGreater(cjt.multiplicity['R']['T'], 1)
+        self.assertEqual(cjt.multiplicity['T']['R'], 1)
+        self.assertGreater(cjt.multiplicity['S']['T'], 1)
+        self.assertEqual(cjt.multiplicity['T']['S'], 1)
+
+        self.assertEqual(cjt.missing_keys['S']['T'], 1)
+        self.assertNotIn('S', cjt.missing_keys['T'])
+        self.assertNotIn('R', cjt.missing_keys['T'])
+        self.assertNotIn('T', cjt.missing_keys['R'])
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/src/test_utils.py
+++ b/src/test_utils.py
@@ -1,0 +1,42 @@
+import duckdb
+
+from src.joinboost.cjt import CJT
+from src.joinboost.joingraph import JoinGraph
+from src.joinboost.semiring import AvgSemiRing
+
+
+"""
+Join Graph for data/synthetic-one_to_many/
+R(ABDH) - T(BFK) - S(FE)
+"""
+
+def initialize_synthetic_one_to_many(semi_ring=AvgSemiRing()):
+    duck_db_conn = duckdb.connect(database=':memory:')
+    join_graph = JoinGraph(duck_db_conn)
+    cjt = CJT(semi_ring=semi_ring, join_graph=join_graph)
+    cjt.add_relation('R', attrs=["A", "D", "H"], relation_address='../data/synthetic-one-to-many/R.csv')
+    cjt.add_relation('S', attrs=["E"], relation_address='../data/synthetic-one-to-many/S.csv')
+    cjt.add_relation('T', relation_address='../data/synthetic-one-to-many/T.csv')
+    cjt.add_join('R', 'T', ['B'], ['B'])
+    cjt.add_join('S', 'T', ['F'], ['F'])
+    return cjt
+
+    """
+    Join Graph for data/synthetic-many-to-many/
+    S(BE) - T(BF) - R(ABDH) 
+    """
+
+
+def initialize_synthetic_many_to_many(semi_ring=AvgSemiRing()):
+    duck_db_conn = duckdb.connect(database=':memory:')
+    join_graph = JoinGraph(duck_db_conn)
+    cjt = CJT(semi_ring=semi_ring, join_graph=join_graph)
+    cjt.add_relation('R', attrs=["D", "H"],
+                     relation_address='../data/synthetic-many-to-many/R.csv')
+    cjt.add_relation('S', attrs=["E"],
+                     relation_address='../data/synthetic-many-to-many/S.csv')
+    cjt.add_relation('T', attrs=["F"],
+                     relation_address='../data/synthetic-many-to-many/T.csv')
+    cjt.add_join('R', 'S', ['B'], ['B'])
+    cjt.add_join('S', 'T', ['B'], ['B'])
+    return cjt


### PR DESCRIPTION
Changes:
- Enum comparison wasn't stable, it didn't always work for me. So I used Enum.value to compare. (https://bobbyhadz.com/blog/python-enum-comparison)
- created test_utils for common test related code.
- moved multiplicity unit tests to the right file.