### PR TITLE
Marker changes

### DIFF
--- a/src/widetable/static/dashboard.html
+++ b/src/widetable/static/dashboard.html
@@ -13,6 +13,10 @@
         stroke: black;
         stroke-width: 7px;
     }
+    .clickable_edge  {
+        opacity: 0;
+        stroke-width: 8px;
+    }
     .markers polyline {
       fill: none;
       stroke: #aaa;
@@ -252,10 +256,6 @@
         .force("center", d3.forceCenter(width / 2, height / 2));
 
 
-
-
-
-
     //list of link containers
     var linkContainers = svg.append('g').attr('class', 'links')
         .selectAll("g")
@@ -284,6 +284,16 @@
         .attr('marker-end', function(d) { if (d.multiplicity[1]==='M') return 'url(#arrowHead)'; else return '';})
         .attr('marker-start', function(d) { if (d.multiplicity[0]==='M') return 'url(#arrowHead)'; else return '';})
         .call(edgeDragEvent);
+
+    var clickableLinks = linkContainers.append('line')
+        .attr('id', 'clickable_edge_' + d.source + '-' + d.target)
+        .attr('x1', (d)=>{return d.source.x;})
+        .attr('y1', (d)=>{return d.source.y;})
+        .attr('x2', (d)=>{return d.target.x;})
+        .attr('y2', (d)=>{return d.target.y;})
+        .attr('class', 'clickable_edge')
+        .attr('opacity', 0)
+        .call(edgeDragEvent)
 
     var sourceLinkTexts = linkContainers
         .append('text')
@@ -367,6 +377,23 @@
                 return Math.max(0, Math.min(width, nodeX));
             })
             .attr("y2", (d)=>{
+                nodeY = Math.max(circleRadius, Math.min(height-circleRadius, d.target.y))
+                return Math.max(0, Math.min(height, nodeY));
+            });
+
+        clickableLinks.attr("x1", (d)=>{
+                nodeX = Math.max(circleRadius, Math.min(width-circleRadius, d.source.x))
+                return Math.max(0, Math.min(width, nodeX));
+            })
+            .attr("y1", (d)=>{
+                nodeY = Math.max(circleRadius, Math.min(height-circleRadius, d.source.y))
+                return Math.max(0, Math.min(height, nodeY));
+            })
+            .attr('x2', (d)=>{
+                nodeX = Math.max(circleRadius, Math.min(width-circleRadius, d.target.x))
+                return Math.max(0, Math.min(width, nodeX));
+            })
+            .attr('y2', (d)=>{
                 nodeY = Math.max(circleRadius, Math.min(height-circleRadius, d.target.y))
                 return Math.max(0, Math.min(height, nodeY));
             });

--- a/src/widetable/static/dashboard.html
+++ b/src/widetable/static/dashboard.html
@@ -159,10 +159,10 @@
         .attr('refX', circleRadius + triangleHeight-3).attr('refY',triangleBase/2 + verticalOffset)
         .attr('orient', 'auto-start-reverse').attr('class','markers')
         .attr('markerUnits', 'userSpaceOnUse')
-           .attr('transform', `translate(0,${verticalOffset})`)
         .append('polyline')
         // triangle ArrowHead
            .attr('class', 'markers')
+           .attr('transform', `translate(0,${verticalOffset})`)
          .attr('points',`0 ${triangleBase/2}, ${triangleHeight +edgeLengthModifier} 0, 0 ${triangleBase/2}, ${triangleHeight +edgeLengthModifier} ${triangleBase}`)
         // .attr('points',`0 0, ${triangleHeight} ${triangleBase/2}, 0 ${triangleBase}`)
 
@@ -175,6 +175,7 @@
         .append('polyline')
         .attr('class', 'markers highlight')
         // triangle ArrowHead
+        .attr('transform', `translate(0,${verticalOffset})`)
         .attr('points',`0 ${triangleBase/2}, ${triangleHeight +edgeLengthModifier} 0, 0 ${triangleBase/2}, ${triangleHeight +edgeLengthModifier} ${triangleBase}`)
 
 

--- a/src/widetable/static/dashboard.html
+++ b/src/widetable/static/dashboard.html
@@ -151,19 +151,22 @@
        defs .append('marker')
         .attr('id','arrowHead').attr('markerWidth','100px').attr('markerHeight','100px')
         .attr('refX', circleRadius + triangleHeight-3).attr('refY',triangleBase/2)
-        .attr('orient', 'auto-start-reverse').attr('class', 'markers')
+        .attr('orient', 'auto-start-reverse')
         .attr('markerUnits', 'userSpaceOnUse')
         .append('polyline')
         // triangle ArrowHead
+           .attr('class', 'markers')
          .attr('points',`0 ${triangleBase/2}, ${triangleHeight} 0, 0 ${triangleBase/2}, ${triangleHeight} ${triangleBase}`)
         // .attr('points',`0 0, ${triangleHeight} ${triangleBase/2}, 0 ${triangleBase}`)
 
     defs .append('marker')
         .attr('id','arrowHeadHighlight').attr('markerWidth','100px').attr('markerHeight','100px')
         .attr('refX', circleRadius + triangleHeight-3).attr('refY',triangleBase/2)
-        .attr('orient', 'auto-start-reverse').attr('class', 'markers highlight')
+        .attr('orient', 'auto-start-reverse')
+        // .attr('class', 'markers highlight')
         .attr('markerUnits', 'userSpaceOnUse')
         .append('polyline')
+        .attr('class', 'markers highlight')
         // triangle ArrowHead
         .attr('points',`0 ${triangleBase/2}, ${triangleHeight} 0, 0 ${triangleBase/2}, ${triangleHeight} ${triangleBase}`)
 

--- a/src/widetable/static/dashboard.html
+++ b/src/widetable/static/dashboard.html
@@ -144,8 +144,8 @@
     var circleRadius = 30
     var linkDistance = 120
 
-    var triangleBase = 15
-    var triangleHeight =15
+    var triangleBase = 20
+    var triangleHeight =20
     var defs = svg.append('defs')
 
        defs .append('marker')
@@ -169,32 +169,6 @@
         // triangle ArrowHead
         .attr('points',`0 ${triangleBase/2}, ${triangleHeight} 0, 0 ${triangleBase/2}, ${triangleHeight} ${triangleBase}`)
 
-      defs.append('marker')
-        .attr('id','startArrowHead').attr('markerWidth','100px').attr('markerHeight','100px')
-        .attr('refX',-1*circleRadius).attr('refY',triangleBase/2).attr('orient', 'auto')
-        .attr('class', 'markers')
-        .attr('markerUnits', 'userSpaceOnUse')
-        .append('polyline')
-        //crows feet
-         .attr('points', `0 0, ${triangleHeight} ${triangleBase/2}, 0 ${triangleBase/2}, ${triangleHeight} ${triangleBase/2}, 0 ${triangleBase}`)
-         // triangle
-        // .attr('points',`0 ${triangleBase/2}, ${triangleHeight} 0, ${triangleHeight} ${triangleBase}`)
-
-        defs .append('marker')
-        .attr('id','blackEndArrowHead').attr('markerWidth','100px').attr('markerHeight','100px')
-        .attr('refX', circleRadius + triangleHeight).attr('refY',1.5*triangleBase/2).attr('orient', 'auto')
-        .attr('class', 'highlightedMarkers')
-        .attr('markerUnits', 'userSpaceOnUse')
-        .append('polyline')
-        .attr('points', `0 ${1.5*triangleBase/2}, ${triangleHeight+4} 0, 0 ${1.5*triangleBase/2}, ${triangleHeight+4} ${1.5*triangleBase/2},0 ${1.5*triangleBase/2}, ${triangleHeight+4} ${1.5*triangleBase}`)
-
-      defs.append('marker')
-        .attr('id','blackStartArrowHead').attr('markerWidth','100px').attr('markerHeight','100px')
-        .attr('refX',-1*circleRadius).attr('refY',1.5*triangleBase/2).attr('orient', 'auto')
-        .attr('class', 'highlightedMarkers')
-        .attr('markerUnits', 'userSpaceOnUse')
-        .append('polyline')
-         .attr('points', `0 0, ${triangleHeight} ${1.5*triangleBase/2}, 0 ${1.5*triangleBase/2}, ${triangleHeight} ${1.5*triangleBase/2}, 0 ${1.5*triangleBase}`)
 
     var schemaArea = d3.select("#session{{session_id}}schema")
 

--- a/src/widetable/static/dashboard.html
+++ b/src/widetable/static/dashboard.html
@@ -374,8 +374,13 @@
             .attr("y", function (d) {return Math.max(circleRadius/2, Math.min(height-circleRadius/2, d.y - this.getBBox().height / 2 ))});
 
         nodeText
-            .attr("x", function (d) {return Math.max(circleRadius/2, Math.min(width-circleRadius/2, d.x - this.getBBox().width / 2))})
-            .attr("y", function (d) {return Math.max(circleRadius/2, Math.min(height-circleRadius/2, d.y - this.getBBox().height / 2 ))});
+            .attr("x", function (d) {
+              nodeX = Math.max(circleRadius, Math.min(width-circleRadius, d.x))
+              return Math.max(0, Math.min(width, nodeX - this.getBBox().width / 2))})
+            .attr("y", function (d) {
+              nodeY = Math.max(circleRadius, Math.min(height-circleRadius, d.y))
+              return Math.max(0, Math.min(height, nodeY - this.getBBox().height / 2 ))});
+
     }
 
     function unHighlightGraph() {

--- a/src/widetable/static/dashboard.html
+++ b/src/widetable/static/dashboard.html
@@ -254,21 +254,6 @@
 
 
 
-    var sourceLinkTexts = linkContainers
-        .append('text')
-        .attr('x',(d)=>{return d.source.x;})
-        .attr('y',(d)=>{return d.source.y;})
-        .text((d, i)=>{return 'placeholder';})
-
-    /*
-     var destLinkTexts = linkContainers
-         .append('text')
-         .attr('x', (d)=>{return d.target.x;})
-         .attr('y', (d)=>{return d.target.y;})
-         .text(function (d, i) {
-             return d.multiplicity[1];
-         })
-         */
 
 
     //list of link containers
@@ -298,7 +283,24 @@
         .attr('id', (d)=>{return "edge_" + d.source + "-" + d.target;})
         .attr('marker-end', function(d) { if (d.multiplicity[1]==='M') return 'url(#arrowHead)'; else return '';})
         .attr('marker-start', function(d) { if (d.multiplicity[0]==='M') return 'url(#arrowHead)'; else return '';})
-        .call(edgeDragEvent)
+        .call(edgeDragEvent);
+
+    var sourceLinkTexts = linkContainers
+        .append('text')
+        .attr('x',(d)=>{return d.source.x;})
+        .attr('y',(d)=>{return d.source.y;})
+        .text((d, i)=>{return 'placeholder';})
+
+    /*
+     var destLinkTexts = linkContainers
+         .append('text')
+         .attr('x', (d)=>{return d.target.x;})
+         .attr('y', (d)=>{return d.target.y;})
+         .text(function (d, i) {
+             return d.multiplicity[1];
+         })
+         */
+
 
     //list of node containers
     var dataEnter = svg

--- a/src/widetable/static/dashboard.html
+++ b/src/widetable/static/dashboard.html
@@ -261,6 +261,36 @@
         })
         */
 
+
+    //list of link containers
+    var linkContainers = svg.append('g').attr('class', 'links')
+        .selectAll("g")
+        .data(graph.links)
+        .enter()
+        .append("g")
+
+    var edgeDragEvent = d3.drag()
+        .on("start", dragstarted)
+        .on("drag", dragged)
+        .on("end", (d,i,nodes) => {
+            unHighlight();
+            dragended(d,i,nodes);
+            highlightRelationAttribute(d.source.id, d.right_keys)
+            highlightRelationAttribute(d.target.id, d.left_keys)
+            highlightRelationNode(d.source.id)
+            highlightRelationSchema(d.source.id)
+            highlightRelationNode(d.target.id)
+            highlightRelationSchema(d.target.id)
+            highlightRelationEdge(d.source.id, d.target.id);
+        })
+
+    var link = linkContainers
+        .append("line")
+        .attr('id', (d)=>{return "edge_" + d.source + "-" + d.target;})
+        .attr('marker-end', function(d) { if (d.multiplicity[1]==='M') return 'url(#arrowHead)'; else return '';})
+        .attr('marker-start', function(d) { if (d.multiplicity[0]==='M') return 'url(#arrowHead)'; else return '';})
+        .call(edgeDragEvent)
+
     //list of node containers
     var dataEnter = svg
         .append("g")
@@ -302,34 +332,6 @@
     nodeAboveText.style('font-family','cursive');
 
 
-        //list of link containers
-    var linkContainers = svg.append('g').attr('class', 'links')
-        .selectAll("g")
-        .data(graph.links)
-        .enter()
-        .append("g")
-
-    var edgeDragEvent = d3.drag()
-        .on("start", dragstarted)
-        .on("drag", dragged)
-        .on("end", (d,i,nodes) => {
-            unHighlight();
-            dragended(d,i,nodes);
-            highlightRelationAttribute(d.source.id, d.right_keys)
-            highlightRelationAttribute(d.target.id, d.left_keys)
-            highlightRelationNode(d.source.id)
-            highlightRelationSchema(d.source.id)
-            highlightRelationNode(d.target.id)
-            highlightRelationSchema(d.target.id)
-            highlightRelationEdge(d.source.id, d.target.id);
-        })
-
-    var link = linkContainers
-        .append("line")
-        .attr('id', (d)=>{return "edge_" + d.source + "-" + d.target;})
-        .attr('marker-end', function(d) { if (d.multiplicity[1]==='M') return 'url(#arrowHead)'; else return '';})
-        .attr('marker-start', function(d) { if (d.multiplicity[0]==='M') return 'url(#arrowHead)'; else return '';})
-        .call(edgeDragEvent)
 
     simulation
         .nodes(graph.nodes)

--- a/src/widetable/static/dashboard.html
+++ b/src/widetable/static/dashboard.html
@@ -13,11 +13,16 @@
         stroke: black;
         stroke-width: 7px;
     }
+    .markers polyline.highlight {
+        fill: none;
+        stroke: black;
+        stroke-width: 7px;
+    }
 
-    .markers {
+    .markers polyline {
       fill: none;
-      stroke: #808080;
-      stroke-width: 3px;
+      stroke: #aaa;
+      stroke-width: 5px;
     }
 
     .highlightedMarkers {
@@ -150,15 +155,16 @@
     var defs = svg.append('defs')
 
        defs .append('marker')
-        .attr('id','endArrowHead').attr('markerWidth','100px').attr('markerHeight','100px')
-        .attr('refX', circleRadius + triangleHeight).attr('refY',triangleBase/2).attr('orient', 'auto-start-reverse')
-        .attr('class', 'markers')
+        .attr('id','arrowHead').attr('markerWidth','100px').attr('markerHeight','100px')
+        .attr('refX', circleRadius + triangleHeight-3).attr('refY',triangleBase/2)
+        .attr('orient', 'auto-start-reverse').attr('class', 'markers')
         .attr('markerUnits', 'userSpaceOnUse')
         .append('polyline')
-        // crows feet
-        .attr('points', `0 ${triangleBase/2}, ${triangleHeight} 0, 0 ${triangleBase/2}, ${triangleHeight} ${triangleBase/2 },0 ${triangleBase/2}, ${triangleHeight} ${triangleBase}`)
         // triangle ArrowHead
+         .attr('points',`0 ${triangleBase/2}, ${triangleHeight} 0, 0 ${triangleBase/2}, ${triangleHeight} ${triangleBase}`)
+
         // .attr('points',`0 0, ${triangleHeight} ${triangleBase/2}, 0 ${triangleBase}`)
+
       defs.append('marker')
         .attr('id','startArrowHead').attr('markerWidth','100px').attr('markerHeight','100px')
         .attr('refX',-1*circleRadius).attr('refY',triangleBase/2).attr('orient', 'auto')
@@ -259,34 +265,7 @@
         .force("center", d3.forceCenter(width / 2, height / 2));
 
 
-        //list of link containers
-    var linkContainers = svg.append('g').attr('class', 'links')
-        .selectAll("g")
-        .data(graph.links)
-        .enter()
-        .append("g")
 
-    var edgeDragEvent = d3.drag()
-        .on("start", dragstarted)
-        .on("drag", dragged)
-        .on("end", (d,i,nodes) => {
-            unHighlight();
-            dragended(d,i,nodes);
-            highlightRelationAttribute(d.source.id, d.right_keys)
-            highlightRelationAttribute(d.target.id, d.left_keys)
-            highlightRelationNode(d.source.id)
-            highlightRelationSchema(d.source.id)
-            highlightRelationNode(d.target.id)
-            highlightRelationSchema(d.target.id)
-            highlightRelationEdge(d.source.id, d.target.id);
-        })
-
-    var link = linkContainers
-        .append("line")
-        .attr('id', (d)=>{return "edge_" + d.source + "-" + d.target;})
-        .attr('marker-end', function(d) { if (d.multiplicity[1]==='M') return 'url(#endArrowHead)'; else return '';})
-        .attr('marker-start', function(d) { if (d.multiplicity[0]==='M') return 'url(#startArrowHead)'; else return '';})
-        .call(edgeDragEvent)
 
    /*
     var sourceLinkTexts = linkContainers
@@ -345,6 +324,34 @@
     nodeAboveText.style('font-family','cursive');
 
 
+        //list of link containers
+    var linkContainers = svg.append('g').attr('class', 'links')
+        .selectAll("g")
+        .data(graph.links)
+        .enter()
+        .append("g")
+
+    var edgeDragEvent = d3.drag()
+        .on("start", dragstarted)
+        .on("drag", dragged)
+        .on("end", (d,i,nodes) => {
+            unHighlight();
+            dragended(d,i,nodes);
+            highlightRelationAttribute(d.source.id, d.right_keys)
+            highlightRelationAttribute(d.target.id, d.left_keys)
+            highlightRelationNode(d.source.id)
+            highlightRelationSchema(d.source.id)
+            highlightRelationNode(d.target.id)
+            highlightRelationSchema(d.target.id)
+            highlightRelationEdge(d.source.id, d.target.id);
+        })
+
+    var link = linkContainers
+        .append("line")
+        .attr('id', (d)=>{return "edge_" + d.source + "-" + d.target;})
+        .attr('marker-end', function(d) { if (d.multiplicity[1]==='M') return 'url(#arrowHead)'; else return '';})
+        .attr('marker-start', function(d) { if (d.multiplicity[0]==='M') return 'url(#arrowHead)'; else return '';})
+        .call(edgeDragEvent)
 
     simulation
         .nodes(graph.nodes)
@@ -389,8 +396,8 @@
 
         link
             .classed('highlight',false)
-            .attr('marker-end', function(d) { if (d.multiplicity[1]==='M') return 'url(#endArrowHead)'; else return '';})
-           .attr('marker-start', function(d) { if (d.multiplicity[0]==='M') return 'url(#startArrowHead)'; else return '';})
+            .attr('marker-end', function(d) { if (d.multiplicity[1]==='M') return 'url(#arrowHead)'; else return '';})
+           .attr('marker-start', function(d) { if (d.multiplicity[0]==='M') return 'url(#arrowHead)'; else return '';})
             .style('color', null)
 
         nodeAboveText
@@ -445,8 +452,8 @@
     function highlightRelationEdge(soruceRelation, targetRelation, color=null) {
         svg.select("#edge_" + soruceRelation + "-" + targetRelation)
            .classed('highlight',true)
-           .attr('marker-end', function(d) { if (d.multiplicity[1]==='M') return 'url(#blackEndArrowHead)'; else return '';})
-           .attr('marker-start', function(d) { if (d.multiplicity[0]==='M') return 'url(#blackStartArrowHead)'; else return '';})
+           .attr('marker-end', function(d) { if (d.multiplicity[1]==='M') return 'url(#arrowHead)'; else return '';})
+           .attr('marker-start', function(d) { if (d.multiplicity[0]==='M') return 'url(#arrowHead)'; else return '';})
            .style('color', color)
     }
 

--- a/src/widetable/static/dashboard.html
+++ b/src/widetable/static/dashboard.html
@@ -352,10 +352,22 @@
 
     function ticked() {
         // make sure that all the links are within boundry
-        link.attr("x1", (d)=>{return Math.max(0, Math.min(width, d.source.x));})
-            .attr("y1", (d)=>{return Math.max(0, Math.min(height, d.source.y));})
-            .attr("x2", (d)=>{return Math.max(0, Math.min(width, d.target.x));})
-            .attr("y2", (d)=>{return Math.max(0, Math.min(height, d.target.y));});
+        link.attr("x1", (d)=>{
+                nodeX = Math.max(circleRadius, Math.min(width-circleRadius, d.source.x))
+                return Math.max(0, Math.min(width, nodeX));
+            })
+            .attr("y1", (d)=>{
+                nodeY = Math.max(circleRadius, Math.min(height-circleRadius, d.source.y))
+                return Math.max(0, Math.min(height, nodeY));
+            })
+            .attr("x2", (d)=>{
+                nodeX = Math.max(circleRadius, Math.min(width-circleRadius, d.target.x))
+                return Math.max(0, Math.min(width, nodeX));
+            })
+            .attr("y2", (d)=>{
+                nodeY = Math.max(circleRadius, Math.min(height-circleRadius, d.target.y))
+                return Math.max(0, Math.min(height, nodeY));
+            });
 
         // // for the texts on the link
         // sourceLinkTexts

--- a/src/widetable/static/dashboard.html
+++ b/src/widetable/static/dashboard.html
@@ -17,6 +17,7 @@
         opacity: 0;
         stroke-width: 8px;
     }
+
     .markers polyline {
       fill: none;
       stroke: #aaa;
@@ -299,7 +300,8 @@
         .append('text')
         .attr('x',(d)=>{return d.source.x;})
         .attr('y',(d)=>{return d.source.y;})
-        .text((d, i)=>{return 'placeholder';});
+        .text((d, i)=>{return 'placeholder';})
+        .call(edgeDragEvent)
 
     /*
      var destLinkTexts = linkContainers

--- a/src/widetable/static/dashboard.html
+++ b/src/widetable/static/dashboard.html
@@ -151,7 +151,7 @@
        defs .append('marker')
         .attr('id','arrowHead').attr('markerWidth','100px').attr('markerHeight','100px')
         .attr('refX', circleRadius + triangleHeight-3).attr('refY',triangleBase/2)
-        .attr('orient', 'auto-start-reverse')
+        .attr('orient', 'auto-start-reverse').attr('class','markers')
         .attr('markerUnits', 'userSpaceOnUse')
         .append('polyline')
         // triangle ArrowHead
@@ -162,8 +162,7 @@
     defs .append('marker')
         .attr('id','arrowHeadHighlight').attr('markerWidth','100px').attr('markerHeight','100px')
         .attr('refX', circleRadius + triangleHeight-3).attr('refY',triangleBase/2)
-        .attr('orient', 'auto-start-reverse')
-        // .attr('class', 'markers highlight')
+        .attr('orient', 'auto-start-reverse').attr('class', 'markers highlight')
         .attr('markerUnits', 'userSpaceOnUse')
         .append('polyline')
         .attr('class', 'markers highlight')

--- a/src/widetable/static/dashboard.html
+++ b/src/widetable/static/dashboard.html
@@ -287,7 +287,7 @@
 
     var clickableLinks = linkContainers
         .append('line')
-        .attr('id', 'clickable_edge_' + d.source + '-' + d.target)
+        .attr('id', (d) => {'clickable_edge_' + d.source + '-' + d.target})
         .attr('x1', function(d){return d.source.x;})
         .attr('y1', function(d){return d.source.y;})
         .attr('x2', function(d){return d.target.x;})

--- a/src/widetable/static/dashboard.html
+++ b/src/widetable/static/dashboard.html
@@ -15,7 +15,11 @@
     }
     .links line.clickable_edge  {
         opacity: 0;
-        stroke-width: 8px;
+        stroke-width: 12px;
+    }
+    .links line.clickable_edge.highlight  {
+        opacity: 0;
+        stroke-width: 16px;
     }
 
     .markers polyline {
@@ -439,6 +443,8 @@
            .attr('marker-start', function(d) { if (d.multiplicity[0]==='M') return 'url(#arrowHead)'; else return '';})
             .style('color', null)
 
+        clickableLinks.classed('highlight',false);
+
         nodeAboveText
             .text("")
     }
@@ -494,6 +500,8 @@
            .attr('marker-end', function(d) { if (d.multiplicity[1]==='M') return 'url(#arrowHeadHighlight)'; else return '';})
            .attr('marker-start', function(d) { if (d.multiplicity[0]==='M') return 'url(#arrowHeadHighlight)'; else return '';})
            .style('color', color)
+        svg.select("#clickable_edge_" + soruceRelation + "-" + targetRelation)
+            .classed('highlight',true)
     }
 
     function highlightRelationAttribute(relation, attribute) {

--- a/src/widetable/static/dashboard.html
+++ b/src/widetable/static/dashboard.html
@@ -292,7 +292,7 @@
 
     var clickableLinks = linkContainers
         .append('line')
-        .attr('id', (d) => {'clickable_edge_' + d.source + '-' + d.target})
+        .attr('id', (d) => {return 'clickable_edge_' + d.source + '-' + d.target})
         .attr('x1', function(d){return d.source.x;})
         .attr('y1', function(d){return d.source.y;})
         .attr('x2', function(d){return d.target.x;})

--- a/src/widetable/static/dashboard.html
+++ b/src/widetable/static/dashboard.html
@@ -144,7 +144,7 @@
     var circleRadius = 30
     var linkDistance = 120
 
-    var triangleBase = 20
+    var triangleBase = 25
     var triangleHeight =20
     //svg elements can be clipped and marker defs are rendered in the corner for some reason
     //this offset will move it out of the corner

--- a/src/widetable/static/dashboard.html
+++ b/src/widetable/static/dashboard.html
@@ -285,12 +285,13 @@
         .attr('marker-start', function(d) { if (d.multiplicity[0]==='M') return 'url(#arrowHead)'; else return '';})
         .call(edgeDragEvent);
 
-    var clickableLinks = linkContainers.append('line')
+    var clickableLinks = linkContainers
+        .append('line')
         .attr('id', 'clickable_edge_' + d.source + '-' + d.target)
-        .attr('x1', (d)=>{return d.source.x;})
-        .attr('y1', (d)=>{return d.source.y;})
-        .attr('x2', (d)=>{return d.target.x;})
-        .attr('y2', (d)=>{return d.target.y;})
+        .attr('x1', function(d){return d.source.x;})
+        .attr('y1', function(d){return d.source.y;})
+        .attr('x2', function(d){return d.target.x;})
+        .attr('y2', function(d){return d.target.y;})
         .attr('class', 'clickable_edge')
         .attr('opacity', 0)
         .call(edgeDragEvent)

--- a/src/widetable/static/dashboard.html
+++ b/src/widetable/static/dashboard.html
@@ -162,8 +162,16 @@
         .append('polyline')
         // triangle ArrowHead
          .attr('points',`0 ${triangleBase/2}, ${triangleHeight} 0, 0 ${triangleBase/2}, ${triangleHeight} ${triangleBase}`)
-
         // .attr('points',`0 0, ${triangleHeight} ${triangleBase/2}, 0 ${triangleBase}`)
+
+    defs .append('marker')
+        .attr('id','arrowHeadHighlighted').attr('markerWidth','100px').attr('markerHeight','100px')
+        .attr('refX', circleRadius + triangleHeight-3).attr('refY',triangleBase/2)
+        .attr('orient', 'auto-start-reverse').attr('class', 'markers highlighted')
+        .attr('markerUnits', 'userSpaceOnUse')
+        .append('polyline')
+        // triangle ArrowHead
+        .attr('points',`0 ${triangleBase/2}, ${triangleHeight} 0, 0 ${triangleBase/2}, ${triangleHeight} ${triangleBase}`)
 
       defs.append('marker')
         .attr('id','startArrowHead').attr('markerWidth','100px').attr('markerHeight','100px')
@@ -452,8 +460,8 @@
     function highlightRelationEdge(soruceRelation, targetRelation, color=null) {
         svg.select("#edge_" + soruceRelation + "-" + targetRelation)
            .classed('highlight',true)
-           .attr('marker-end', function(d) { if (d.multiplicity[1]==='M') return 'url(#arrowHead)'; else return '';})
-           .attr('marker-start', function(d) { if (d.multiplicity[0]==='M') return 'url(#arrowHead)'; else return '';})
+           .attr('marker-end', function(d) { if (d.multiplicity[1]==='M') return 'url(#arrowHeadHighlighted)'; else return '';})
+           .attr('marker-start', function(d) { if (d.multiplicity[0]==='M') return 'url(#arrowHeadHighlighted)'; else return '';})
            .style('color', color)
     }
 

--- a/src/widetable/static/dashboard.html
+++ b/src/widetable/static/dashboard.html
@@ -373,8 +373,8 @@
 
         // // for the texts on the link
         sourceLinkTexts
-            .attr('x', (d)=>{return Math.max(0, Math.min(width,d.source.x + (d.target.x - d.source.x) / 2))})
-            .attr('y', (d)=>{return Math.max(0, Math.min(height, d.source.y + (d.target.y - d.source.y) / 2))});
+            .attr('x', (d)=>{return Math.max(0, Math.min(width,d.source.x + (d.target.x - d.source.x) / 2 - this.getBBox().width/2))})
+            .attr('y', (d)=>{return Math.max(0, Math.min(height, d.source.y + (d.target.y - d.source.y)))});
 
         // destLinkTexts
         //     .attr('x', (d)=>{return Math.max(0, Math.min(width,d.source.x + 3 * (d.target.x - d.source.x) / 5))})

--- a/src/widetable/static/dashboard.html
+++ b/src/widetable/static/dashboard.html
@@ -151,7 +151,7 @@
 
        defs .append('marker')
         .attr('id','endArrowHead').attr('markerWidth','100px').attr('markerHeight','100px')
-        .attr('refX', circleRadius + triangleHeight).attr('refY',triangleBase/2).attr('orient', 'auto')
+        .attr('refX', circleRadius + triangleHeight).attr('refY',triangleBase/2).attr('orient', 'auto-start-reverse')
         .attr('class', 'markers')
         .attr('markerUnits', 'userSpaceOnUse')
         .append('polyline')

--- a/src/widetable/static/dashboard.html
+++ b/src/widetable/static/dashboard.html
@@ -293,7 +293,7 @@
         .attr('x2', function(d){return d.target.x;})
         .attr('y2', function(d){return d.target.y;})
         .attr('class', 'clickable_edge')
-        // .call(edgeDragEvent)
+        .call(edgeDragEvent)
 
     var sourceLinkTexts = linkContainers
         .append('text')

--- a/src/widetable/static/dashboard.html
+++ b/src/widetable/static/dashboard.html
@@ -456,7 +456,7 @@
     function highlightRelationEdge(soruceRelation, targetRelation, color=null) {
         svg.select("#edge_" + soruceRelation + "-" + targetRelation)
            .classed('highlight',true)
-           .attr('marker-end', function(d) { if (d.multiplicity[1]==='M') return 'url(#arrowHeadHighlighted)'; else return '';})
+           .attr('marker-end', function(d) { if (d.multiplicity[1]==='M') return 'url(#arrowHeadHighlight)'; else return '';})
            .attr('marker-start', function(d) { if (d.multiplicity[0]==='M') return 'url(#arrowHeadHighlight)'; else return '';})
            .style('color', color)
     }

--- a/src/widetable/static/dashboard.html
+++ b/src/widetable/static/dashboard.html
@@ -289,7 +289,7 @@
         .append('text')
         .attr('x',(d)=>{return d.source.x;})
         .attr('y',(d)=>{return d.source.y;})
-        .text((d, i)=>{return 'placeholder';})
+        .text((d, i)=>{return 'placeholder';});
 
     /*
      var destLinkTexts = linkContainers
@@ -373,8 +373,10 @@
 
         // // for the texts on the link
         sourceLinkTexts
-            .attr('x', (d)=>{return Math.max(0, Math.min(width,d.source.x + (d.target.x - d.source.x) / 2 - this.getBBox().width/2))})
-            .attr('y', (d)=>{return Math.max(0, Math.min(height, d.source.y + (d.target.y - d.source.y)))});
+            .attr('x', function(d) {
+                return Math.max(0, Math.min(width,d.source.x + (d.target.x - d.source.x) / 2 - this.getBBox().width/2))
+              })
+            .attr('y', (d)=>{return Math.max(0, Math.min(height, d.source.y + (d.target.y - d.source.y)/2))});
 
         // destLinkTexts
         //     .attr('x', (d)=>{return Math.max(0, Math.min(width,d.source.x + 3 * (d.target.x - d.source.x) / 5))})

--- a/src/widetable/static/dashboard.html
+++ b/src/widetable/static/dashboard.html
@@ -159,6 +159,7 @@
         .attr('refX', circleRadius + triangleHeight-3).attr('refY',triangleBase/2 + verticalOffset)
         .attr('orient', 'auto-start-reverse').attr('class','markers')
         .attr('markerUnits', 'userSpaceOnUse')
+           .attr('transform', `translate(0,${verticalOffset})`)
         .append('polyline')
         // triangle ArrowHead
            .attr('class', 'markers')
@@ -170,6 +171,7 @@
         .attr('refX', circleRadius + triangleHeight-3).attr('refY',triangleBase/2 + verticalOffset)
         .attr('orient', 'auto-start-reverse').attr('class', 'markers highlight')
         .attr('markerUnits', 'userSpaceOnUse')
+        .attr('transform', `translate(0,${verticalOffset})`)
         .append('polyline')
         .attr('class', 'markers highlight')
         // triangle ArrowHead

--- a/src/widetable/static/dashboard.html
+++ b/src/widetable/static/dashboard.html
@@ -254,21 +254,21 @@
 
 
 
-   /*
     var sourceLinkTexts = linkContainers
         .append('text')
         .attr('x',(d)=>{return d.source.x;})
         .attr('y',(d)=>{return d.source.y;})
-        .text((d, i)=>{return d.multiplicity[0] + '';})
+        .text((d, i)=>{return 'placeholder';})
 
-    var destLinkTexts = linkContainers
-        .append('text')
-        .attr('x', (d)=>{return d.target.x;})
-        .attr('y', (d)=>{return d.target.y;})
-        .text(function (d, i) {
-            return d.multiplicity[1];
-        })
-        */
+    /*
+     var destLinkTexts = linkContainers
+         .append('text')
+         .attr('x', (d)=>{return d.target.x;})
+         .attr('y', (d)=>{return d.target.y;})
+         .text(function (d, i) {
+             return d.multiplicity[1];
+         })
+         */
 
 
     //list of link containers
@@ -370,9 +370,9 @@
             });
 
         // // for the texts on the link
-        // sourceLinkTexts
-        //     .attr('x', (d)=>{return Math.max(0, Math.min(width,d.source.x + 2* (d.target.x - d.source.x) / 5))})
-        //     .attr('y', (d)=>{return Math.max(0, Math.min(height, d.source.y + 2* (d.target.y - d.source.y) / 5))});
+        sourceLinkTexts
+            .attr('x', (d)=>{return Math.max(0, Math.min(width,d.source.x + (d.target.x - d.source.x) / 2))})
+            .attr('y', (d)=>{return Math.max(0, Math.min(height, d.source.y + (d.target.y - d.source.y) / 2))});
 
         // destLinkTexts
         //     .attr('x', (d)=>{return Math.max(0, Math.min(width,d.source.x + 3 * (d.target.x - d.source.x) / 5))})

--- a/src/widetable/static/dashboard.html
+++ b/src/widetable/static/dashboard.html
@@ -293,8 +293,7 @@
         .attr('x2', function(d){return d.target.x;})
         .attr('y2', function(d){return d.target.y;})
         .attr('class', 'clickable_edge')
-        .attr('opacity', 0)
-        .call(edgeDragEvent)
+        // .call(edgeDragEvent)
 
     var sourceLinkTexts = linkContainers
         .append('text')

--- a/src/widetable/static/dashboard.html
+++ b/src/widetable/static/dashboard.html
@@ -13,7 +13,7 @@
         stroke: black;
         stroke-width: 7px;
     }
-    .clickable_edge  {
+    .links line.clickable_edge  {
         opacity: 0;
         stroke-width: 8px;
     }

--- a/src/widetable/static/dashboard.html
+++ b/src/widetable/static/dashboard.html
@@ -146,28 +146,34 @@
 
     var triangleBase = 20
     var triangleHeight =20
+    //svg elements can be clipped and marker defs are rendered in the corner for some reason
+    //this offset will move it out of the corner
+    var verticalOffset = 5
+
+    // this is to make the edges a bit longer.
+    var edgeLengthModifier = 3
     var defs = svg.append('defs')
 
        defs .append('marker')
         .attr('id','arrowHead').attr('markerWidth','100px').attr('markerHeight','100px')
-        .attr('refX', circleRadius + triangleHeight-3).attr('refY',triangleBase/2)
+        .attr('refX', circleRadius + triangleHeight-3).attr('refY',triangleBase/2 + verticalOffset)
         .attr('orient', 'auto-start-reverse').attr('class','markers')
         .attr('markerUnits', 'userSpaceOnUse')
         .append('polyline')
         // triangle ArrowHead
            .attr('class', 'markers')
-         .attr('points',`0 ${triangleBase/2}, ${triangleHeight} 0, 0 ${triangleBase/2}, ${triangleHeight} ${triangleBase}`)
+         .attr('points',`0 ${triangleBase/2}, ${triangleHeight +edgeLengthModifier} 0, 0 ${triangleBase/2}, ${triangleHeight +edgeLengthModifier} ${triangleBase}`)
         // .attr('points',`0 0, ${triangleHeight} ${triangleBase/2}, 0 ${triangleBase}`)
 
     defs .append('marker')
         .attr('id','arrowHeadHighlight').attr('markerWidth','100px').attr('markerHeight','100px')
-        .attr('refX', circleRadius + triangleHeight-3).attr('refY',triangleBase/2)
+        .attr('refX', circleRadius + triangleHeight-3).attr('refY',triangleBase/2 + verticalOffset)
         .attr('orient', 'auto-start-reverse').attr('class', 'markers highlight')
         .attr('markerUnits', 'userSpaceOnUse')
         .append('polyline')
         .attr('class', 'markers highlight')
         // triangle ArrowHead
-        .attr('points',`0 ${triangleBase/2}, ${triangleHeight} 0, 0 ${triangleBase/2}, ${triangleHeight} ${triangleBase}`)
+        .attr('points',`0 ${triangleBase/2}, ${triangleHeight +edgeLengthModifier} 0, 0 ${triangleBase/2}, ${triangleHeight +edgeLengthModifier} ${triangleBase}`)
 
 
     var schemaArea = d3.select("#session{{session_id}}schema")
@@ -358,15 +364,15 @@
         //     .attr('y', (d)=>{return Math.max(0, Math.min(height, d.source.y + 3 * (d.target.y - d.source.y) / 5))});
 
         node
-            .attr("transform", (d)=>{return "translate(" + Math.max(0, Math.min(width, d.x)) +
-                                    ", " + Math.max(0, Math.min(height, d.y)) + ")";});
+            .attr("transform", (d)=>{return "translate(" + Math.max(circleRadius, Math.min(width-circleRadius, d.x)) +
+                                    ", " + Math.max(circleRadius, Math.min(height-circleRadius, d.y)) + ")";});
         nodeAboveText
-            .attr("x", function (d) {return Math.max(0, Math.min(width, d.x - this.getBBox().width / 2))})
-            .attr("y", function (d) {return Math.max(0, Math.min(height, d.y - this.getBBox().height / 2 ))});
+            .attr("x", function (d) {return Math.max(circleRadius/2, Math.min(width-circleRadius/2, d.x - this.getBBox().width / 2))})
+            .attr("y", function (d) {return Math.max(circleRadius/2, Math.min(height-circleRadius/2, d.y - this.getBBox().height / 2 ))});
 
         nodeText
-            .attr("x", function (d) {return Math.max(0, Math.min(width, d.x - this.getBBox().width / 2))})
-            .attr("y", function (d) {return Math.max(0, Math.min(height, d.y - this.getBBox().height / 2 ))});
+            .attr("x", function (d) {return Math.max(circleRadius/2, Math.min(width-circleRadius/2, d.x - this.getBBox().width / 2))})
+            .attr("y", function (d) {return Math.max(circleRadius/2, Math.min(height-circleRadius/2, d.y - this.getBBox().height / 2 ))});
     }
 
     function unHighlightGraph() {

--- a/src/widetable/static/dashboard.html
+++ b/src/widetable/static/dashboard.html
@@ -13,22 +13,16 @@
         stroke: black;
         stroke-width: 7px;
     }
-    .markers polyline.highlight {
-        fill: none;
-        stroke: black;
-        stroke-width: 7px;
-    }
-
     .markers polyline {
       fill: none;
       stroke: #aaa;
       stroke-width: 5px;
     }
 
-    .highlightedMarkers {
-      fill:none;
-      stroke: black;
-      stroke-width: 5px;
+    .markers polyline.highlight {
+        fill: none;
+        stroke: black;
+        stroke-width: 7px;
     }
 
     .nodes circle {
@@ -165,9 +159,9 @@
         // .attr('points',`0 0, ${triangleHeight} ${triangleBase/2}, 0 ${triangleBase}`)
 
     defs .append('marker')
-        .attr('id','arrowHeadHighlighted').attr('markerWidth','100px').attr('markerHeight','100px')
+        .attr('id','arrowHeadHighlight').attr('markerWidth','100px').attr('markerHeight','100px')
         .attr('refX', circleRadius + triangleHeight-3).attr('refY',triangleBase/2)
-        .attr('orient', 'auto-start-reverse').attr('class', 'markers highlighted')
+        .attr('orient', 'auto-start-reverse').attr('class', 'markers highlight')
         .attr('markerUnits', 'userSpaceOnUse')
         .append('polyline')
         // triangle ArrowHead
@@ -461,7 +455,7 @@
         svg.select("#edge_" + soruceRelation + "-" + targetRelation)
            .classed('highlight',true)
            .attr('marker-end', function(d) { if (d.multiplicity[1]==='M') return 'url(#arrowHeadHighlighted)'; else return '';})
-           .attr('marker-start', function(d) { if (d.multiplicity[0]==='M') return 'url(#arrowHeadHighlighted)'; else return '';})
+           .attr('marker-start', function(d) { if (d.multiplicity[0]==='M') return 'url(#arrowHeadHighlight)'; else return '';})
            .style('color', color)
     }
 


### PR DESCRIPTION
- Reduced marker definitions from 4 to 2. It's not easy to make it 1 because marker elements do not inherit anything from the referencing element.
  - https://stackoverflow.com/a/16665510/7470050, context-stroke can't be used cause we only want it to be for one or 2 marker elements.
- added a thicker transparent line to make the edges more clickable. the width can be modified in clickable_edge css.
- added boundary checks to ensure that circle, text and edge cannot be dragged out of the viewbox.
- added some placeholder text in the middle of the edge. this can also be dragged and clicked (like an edge).
